### PR TITLE
Catch SyntaxError when reading CLI args

### DIFF
--- a/dicfg/factory.py
+++ b/dicfg/factory.py
@@ -107,8 +107,8 @@ def _is_object(value):
 
 def _dont_build(value):
     if isinstance(value, dict):
-        return value.pop('!build', False)
-    return False 
+        return value.pop("!build", False)
+    return False
 
 
 def build_config(config: dict):

--- a/dicfg/reader.py
+++ b/dicfg/reader.py
@@ -158,7 +158,7 @@ def _create_dict_from_keys(keys: list, value) -> dict:
     if len(keys) <= 1:
         try:
             value = ast.literal_eval(value)
-        except ValueError:
+        except (ValueError, SyntaxError):
             value = ast.literal_eval("'" + value + "'")
         dictionary[keys[0]] = value
     else:

--- a/tests/dicfg_test.py
+++ b/tests/dicfg_test.py
@@ -103,16 +103,17 @@ def test_replace_error():
         user_config_path = Path("./testconfigs/user_config_replace_error.yml")
         _ = config_reader.read(user_config_path)
 
+
 def test_dont_build():
     config_reader_dont_build = ConfigReader(
         name="testconfig_dont_build",
         main_config_path="./testconfigs/config_dont_build.yml",
     )
     config_dont_build = config_reader_dont_build.read()
-    config_dont_build_build = build_config(config_dont_build)['default']
+    config_dont_build_build = build_config(config_dont_build)["default"]
     config_reader = ConfigReader(
         name="test_config",
         main_config_path="./testconfigs/config.yml",
     )
-    config= config_reader.read()['default']
+    config = config_reader.read()["default"]
     assert config_dont_build_build == config


### PR DESCRIPTION
Fix the reading of CLI arguments. ast.literal_eval raises a SyntaxError in some cases, but only ValueErrors are caught in the original code. See more info in issue #12 